### PR TITLE
some refactoring

### DIFF
--- a/src/main/java/me/char321/chunkcacher/WorldCache.java
+++ b/src/main/java/me/char321/chunkcacher/WorldCache.java
@@ -9,15 +9,13 @@ import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.ChunkSerializer;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.gen.GeneratorOptions;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class WorldCache {
     public static boolean isGenerating = false;
-    public static GeneratorOptions lastGeneratorOptions = null;
-    public static Map<RegistryKey<World>, Long2ObjectLinkedOpenHashMap<NbtCompound>> cache = new HashMap<>();
+    private static final Map<RegistryKey<World>, Long2ObjectLinkedOpenHashMap<NbtCompound>> cache = new HashMap<>();
 
     public static void addChunk(ChunkPos chunkPos, Chunk chunk, ServerWorld world) {
         cache.computeIfAbsent(world.getRegistryKey(), k -> new Long2ObjectLinkedOpenHashMap<>()).put(chunkPos.toLong(), ChunkSerializer.serialize(world, chunk));
@@ -31,22 +29,6 @@ public class WorldCache {
         Long2ObjectLinkedOpenHashMap<NbtCompound> map = cache.get(world.getRegistryKey());
         if (map == null) return null;
         return map.get(chunkPos.toLong());
-    }
-
-    /**
-     * Checks if the generator options have changed, if so, clear the cache
-     * dude github copilot is so cool it auto generated these comments
-     */
-    public static void checkGeneratorOptions(GeneratorOptions generatorOptions) {
-        if (lastGeneratorOptions == null ||
-                lastGeneratorOptions.getSeed() != generatorOptions.getSeed() ||
-                lastGeneratorOptions.shouldGenerateStructures() != generatorOptions.shouldGenerateStructures() ||
-                lastGeneratorOptions.hasBonusChest() != generatorOptions.hasBonusChest() ||
-//TODO: different superflat presets for example are not detected, so the cache is not cleared and the world is not generated correctly
-                !lastGeneratorOptions.getChunkGenerator().getClass().equals(generatorOptions.getChunkGenerator().getClass())) {
-            cache.clear();
-            lastGeneratorOptions = generatorOptions;
-        }
     }
 
     public static void clearCache() {

--- a/src/main/java/me/char321/chunkcacher/WorldCache.java
+++ b/src/main/java/me/char321/chunkcacher/WorldCache.java
@@ -9,12 +9,14 @@ import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.ChunkSerializer;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.GeneratorOptions;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class WorldCache {
     public static boolean isGenerating = false;
+    private static GeneratorOptions lastGeneratorOptions;
     private static final Map<RegistryKey<World>, Long2ObjectLinkedOpenHashMap<NbtCompound>> cache = new HashMap<>();
 
     public static void addChunk(ChunkPos chunkPos, Chunk chunk, ServerWorld world) {
@@ -29,6 +31,24 @@ public class WorldCache {
         Long2ObjectLinkedOpenHashMap<NbtCompound> map = cache.get(world.getRegistryKey());
         if (map == null) return null;
         return map.get(chunkPos.toLong());
+    }
+
+    /**
+     * Checks if the generator options have changed, if so, clear the cache
+     * dude github copilot is so cool it auto generated these comments
+
+     * kept as fallback just in case some Atum update messes anything up
+     * not perfect but good enough for that purpose
+     */
+    public static void checkGeneratorOptions(GeneratorOptions generatorOptions) {
+        if (lastGeneratorOptions == null ||
+                lastGeneratorOptions.getSeed() != generatorOptions.getSeed() ||
+                lastGeneratorOptions.shouldGenerateStructures() != generatorOptions.shouldGenerateStructures() ||
+                lastGeneratorOptions.isFlatWorld() != generatorOptions.isFlatWorld()
+        ) {
+            clearCache();
+            lastGeneratorOptions = generatorOptions;
+        }
     }
 
     public static void clearCache() {

--- a/src/main/java/me/char321/chunkcacher/mixin/ChunkSerializerMixin.java
+++ b/src/main/java/me/char321/chunkcacher/mixin/ChunkSerializerMixin.java
@@ -21,14 +21,14 @@ public class ChunkSerializerMixin {
     @ModifyVariable(method = "serialize", at = @At("RETURN"), ordinal = 2)
     private static NbtCompound serializeHeightmaps2(NbtCompound nbtCompound, ServerWorld world, Chunk chunk) {
         if (chunk instanceof ProtoChunk) {
-            nbtCompound.put(Heightmap.Type.WORLD_SURFACE_WG.getName(), new NbtLongArray((chunk.getHeightmap(Heightmap.Type.WORLD_SURFACE_WG)).asLongArray()));
-            nbtCompound.put(Heightmap.Type.OCEAN_FLOOR_WG.getName(), new NbtLongArray((chunk.getHeightmap(Heightmap.Type.OCEAN_FLOOR_WG)).asLongArray()));
+            nbtCompound.put(Heightmap.Type.WORLD_SURFACE_WG.getName(), new NbtLongArray(chunk.getHeightmap(Heightmap.Type.WORLD_SURFACE_WG).asLongArray()));
+            nbtCompound.put(Heightmap.Type.OCEAN_FLOOR_WG.getName(), new NbtLongArray(chunk.getHeightmap(Heightmap.Type.OCEAN_FLOOR_WG).asLongArray()));
         }
         return nbtCompound;
     }
 
     @Redirect(method = "deserialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/ChunkStatus;getHeightmapTypes()Ljava/util/EnumSet;"))
-    private static EnumSet<Heightmap.Type> deserializeHeightmaps(ChunkStatus instance) {
+    private static EnumSet<Heightmap.Type> deserializeHeightmaps(ChunkStatus status) {
         return EnumSet.allOf(Heightmap.Type.class);
     }
 }

--- a/src/main/java/me/char321/chunkcacher/mixin/MinecraftServerMixin.java
+++ b/src/main/java/me/char321/chunkcacher/mixin/MinecraftServerMixin.java
@@ -2,7 +2,10 @@ package me.char321.chunkcacher.mixin;
 
 import me.char321.chunkcacher.WorldCache;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.SaveProperties;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -10,9 +13,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
 
+    @Shadow @Final protected SaveProperties saveProperties;
+
     @Inject(method = "createWorlds", at = @At("HEAD"))
     private void isGenerating(CallbackInfo ci) {
         WorldCache.isGenerating = true;
+        WorldCache.checkGeneratorOptions(this.saveProperties.getGeneratorOptions());
     }
 
     @Inject(method = "loadWorld", at = @At("TAIL"))

--- a/src/main/java/me/char321/chunkcacher/mixin/MinecraftServerMixin.java
+++ b/src/main/java/me/char321/chunkcacher/mixin/MinecraftServerMixin.java
@@ -2,28 +2,21 @@ package me.char321.chunkcacher.mixin;
 
 import me.char321.chunkcacher.WorldCache;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.WorldGenerationProgressListener;
-import net.minecraft.world.SaveProperties;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
-    @Shadow @Final protected SaveProperties saveProperties;
 
     @Inject(method = "createWorlds", at = @At("HEAD"))
-    public void isGenerating(WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci) {
+    private void isGenerating(CallbackInfo ci) {
         WorldCache.isGenerating = true;
-
-        WorldCache.checkGeneratorOptions(saveProperties.getGeneratorOptions());
     }
 
     @Inject(method = "loadWorld", at = @At("TAIL"))
-    public void isNotGenerating(CallbackInfo ci) {
+    private void isNotGenerating(CallbackInfo ci) {
         WorldCache.isGenerating = false;
     }
 }

--- a/src/main/java/me/char321/chunkcacher/mixin/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/char321/chunkcacher/mixin/ThreadedAnvilChunkStorageMixin.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @Mixin(ThreadedAnvilChunkStorage.class)
@@ -26,15 +25,18 @@ public class ThreadedAnvilChunkStorageMixin {
     @Shadow @Final private ServerWorld world;
 
     @Inject(method = "method_17225", at = @At("RETURN"))
-    private void addToCache(ChunkPos chunkPos, ChunkHolder chunkHolder, ChunkStatus chunkStatus, List<?> list, CallbackInfoReturnable<CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>>> cir) {
-        CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>> completableFuture = cir.getReturnValue();
-        if (WorldCache.shouldCache() && completableFuture.isDone() && !chunkStatus.isAtLeast(ChunkStatus.FEATURES)) {
-            completableFuture.getNow(null).ifLeft((chunk) -> WorldCache.addChunk(chunkPos, chunk, world));
+    private void addToCache(CallbackInfoReturnable<CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>>> cir) {
+        if (WorldCache.shouldCache() && cir.getReturnValue().isDone()) {
+            cir.getReturnValue().getNow(null).ifLeft((chunk) -> {
+                if (!chunk.getStatus().isAtLeast(ChunkStatus.FEATURES)) {
+                    WorldCache.addChunk(chunk.getPos(), chunk, world);
+                }
+            });
         }
     }
 
-    @ModifyVariable(method = "getUpdatedChunkNbt", at = @At(value="STORE"))
-    public NbtCompound loadFromCache(NbtCompound nbtCompound, ChunkPos pos) {
+    @ModifyVariable(method = "getUpdatedChunkNbt", at = @At("STORE"))
+    private NbtCompound loadFromCache(NbtCompound nbtCompound, ChunkPos pos) {
         if (WorldCache.shouldCache() && nbtCompound == null) {
             return WorldCache.getChunkNbt(pos, world);
         }

--- a/src/main/java/me/char321/chunkcacher/mixin/TitleScreenMixin.java
+++ b/src/main/java/me/char321/chunkcacher/mixin/TitleScreenMixin.java
@@ -3,19 +3,17 @@ package me.char321.chunkcacher.mixin;
 import me.char321.chunkcacher.WorldCache;
 import me.voidxwalker.autoreset.Atum;
 import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.gui.screen.option.OptionsScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TitleScreen.class)
 public class TitleScreenMixin {
+
     @Inject(method = "init", at = @At("HEAD"))
-    public void clearCacheOnAtumQuit(CallbackInfo ci) {
-        if (!Atum.isRunning) {
+    private void clearCacheOnAtumQuit(CallbackInfo ci) {
+        if (!Atum.isRunning || Atum.seed == null || Atum.seed.isEmpty()) {
             WorldCache.clearCache();
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,7 +13,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.2",
-    "minecraft": ">=1.16 <=1.18.2",
+    "minecraft": ">=1.16 <=1.17.1",
     "atum": "*"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,7 +13,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.2",
-    "minecraft": ">=1.16 <=1.17.1",
+    "minecraft": ">=1.16 <=1.18.2",
     "atum": "*"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,15 +7,13 @@
   "authors": [],
   "contact": {},
   "license": "MIT",
-  "icon": "assets/chunkcacher/icon.png",
   "environment": "*",
-  "entrypoints": {},
   "mixins": [
     "chunkcacher.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.12.2",
-    "minecraft": "1.16.x",
+    "minecraft": ">=1.16 <=1.17.1",
     "atum": "*"
   }
 }


### PR DESCRIPTION
remove checkGeneratorOptions() and instead check atum seed
refactor addToCache inject to be 1.17 compatible (it also just seems nicer to get status and chunkpos from the chunk itself and not from somewhere earlier in the code)
some small stuff like private mixin methods and private final cache